### PR TITLE
adding frontend functionality for the other wordlist indices

### DIFF
--- a/src/lib/components/IndexRow.svelte
+++ b/src/lib/components/IndexRow.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+	import type { WordListWord } from '$lib/types/word_list_index.type';
+
+	export let word: WordListWord;
+	export let language: string;
+	export let id: string;
+	export let treeData;
+	export let wordType;
+
+	let treeDataStr = JSON.stringify(treeData);
+	let doubletreeContainer: HTMLElement;
+
+	$: isExpanded = false;
+	$: isTreeShown = false;
+
+	let lemmaPOS = `${word.lemma.toLowerCase()}/${word.pos}`;
+
+	function toggleIsExpanded(_e: Event) {
+		isExpanded = !isExpanded;
+	}
+
+	function toggleIsTreeShown(obj: any, counter: string) {
+		if (language == 'latin') {
+			isTreeShown = !isTreeShown;
+			/*let dbtreerow = doubletreeContainer;*/
+
+			const dbtreerow = document.getElementById(`doubletree${counter}`);
+
+			if (isTreeShown) {
+				if (obj.indexOf(' | ') > -1) {
+					obj = obj.replace(' | ', '|');
+				}
+				// @ts-expect-error --- drawDT is declared in /vendor/doubletreejs/doubletree-kwic-extras.js
+				drawDT(treeDataStr, obj, counter);
+			} else {
+				const svg = dbtreerow?.querySelector('svg');
+				if (svg) {
+					doubletreeContainer.removeChild(svg as Node);
+				}
+			}
+		}
+	}
+
+	/*if (isTreeShown) {
+			const prefixes = [
+				{ name: 'root' },
+				{ parent: 'root', name: 'prefix1 prefix1 prefix1' },
+				{ parent: 'root', name: 'prefix2 prefix2 prefix2' },
+				{ parent: 'root', name: 'prefix3 prefix3 prefix3' }
+			];
+
+			const suffixes = [
+				{ name: 'root' },
+				{ parent: 'root', name: 'suffix1 suffix1 suffix1' },
+				{ parent: 'root', name: 'suffix2 suffix2 suffix2' },
+				{ parent: 'root', name: 'suffix3 suffix3 suffix3' }
+			];
+			drawTree(doubletreeContainer, 'root', prefixes, suffixes);
+		} else {
+			const svg = doubletreeContainer.querySelector('svg');
+
+			doubletreeContainer.removeChild(svg as Node);
+		}
+	}*/
+
+	function getDictionary(language: string, lemma: string) {
+		switch (language) {
+			case 'latin':
+				return `http://www.perseus.tufts.edu/hopper/resolveform?type=exact&lookup=${lemma}&lang=la`;
+			case 'greek':
+				return `https://www.perseus.tufts.edu/hopper/morph?l=${lemma}&la=greek`;
+			case 'hebrew':
+				return `https://www.morfix.co.il/en/${lemma}`;
+			case 'aramaic':
+				return `https://cal.huc.edu/browseSKEYheaders.php?tools=on&first3=${lemma.slice(0, 3)}`;
+		}
+	}
+</script>
+
+<tr class="alpha_link"><span id={word.lemma.normalize('NFD')[0]} /></tr>
+<tr class={`level0 pos${word.pos}`}>
+	<td colspan="2"
+		>&nbsp;<br />
+		<table>
+			<tr>
+				<td rowspan="2" style="vertical-align:center;">
+					<button type="button" id="button{id}" class="btn btn-primary" on:click={toggleIsExpanded}
+						>{isExpanded ? '-' : '+'}</button
+					>
+				</td>
+				<td>
+				    {#if wordType == 'true'}
+					<span class="font-bold">{word.lemma}</span>
+					{word.pos} ({word.count}) | <span class="italic">type: {word.type}</span>
+					{:else}
+					<span class="font-bold">{word.lemma}</span>
+					{word.pos} ({word.count})
+					{/if}
+				</td>
+			</tr>
+			<tr>
+				<td>
+					<a href={getDictionary(language, word.lemma)} target="_blank">
+						<img class="dictionary-icon" src="/img/dictionary.png" alt="Dictionary icon" />
+					</a>
+					<button type="button" on:click={() => toggleIsTreeShown(lemmaPOS, id)}>
+						{#if language == 'latin'}
+							<img class="tree-icon" src="/img/tree-icon.png" alt="tree icon" />
+						{:else}
+							<img
+								class="tree-icon"
+								style="opacity:0.25;"
+								src="/img/tree-icon.png"
+								alt="tree icon"
+							/>
+						{/if}
+					</button>
+				</td>
+			</tr>
+		</table>
+	</td>
+</tr>
+
+{#if isExpanded}
+	{#each Object.values(word.forms) as form}
+		{#each form.kwics as kwic, index}
+			{#if index == 0}
+				<tr class="level1 tog">
+					<td rowspan={form.count} class="formentry" style="vertical-align:top;">
+						{form.form}
+						<br />
+						↳ {form.pos} ({form.count})
+					</td>
+					<td style="vertical-align:top">
+						{kwic[0][0]} <b>{kwic[0][1]}</b>
+						{kwic[0][2]} (<a href="/inscriptions/{kwic[1]}" style="color: grey">{kwic[1]}</a>)
+					</td>
+				</tr>
+			{:else}
+				<tr class="level1 tog">
+					<td>
+						{kwic[0][0]} <b>{kwic[0][1]}</b>
+						{kwic[0][2]} (<a href="/inscriptions/{kwic[1]}" style="color: grey">{kwic[1]}</a>)
+					</td>
+				</tr>
+			{/if}
+		{/each}
+		<tr>&nbsp;</tr>
+	{/each}
+{/if}
+
+<div id="doubletreerow{id}">
+	<div id="doubletree{id}" bind:this={doubletreeContainer} />
+</div>

--- a/src/lib/types/word_list_index.type.ts
+++ b/src/lib/types/word_list_index.type.ts
@@ -1,0 +1,52 @@
+/*export type WordListWord = {
+    count: number;
+    lemma: string;
+    pos: string;
+}*/
+
+export type Kwic = [string[], string];
+
+export type Form = {
+  form: string;
+  pos: string;
+  kwics: Kwic[];
+  count: number;
+};
+
+/* added type, key */
+
+export type Lemma = {
+  lemma: string;
+  pos: string;
+  type: string;
+  key: string;
+  cf: string[];
+  forms: Record<string, Form>;
+  count: number;
+};
+
+export type WordListWord = {
+  count: number;
+  forms: Form[];
+  lemma: string;
+  lemmas: Lemma[];
+  pos: string;
+};
+
+export type NestedWordList = {
+  [key: string]: WordListWord;
+};
+
+export type Index = {
+  title: WordListWord;
+  military: WordListWord;
+  ethnicon: WordListWord;
+  relationship: WordListWord;
+  location: WordListWord;
+  date: WordListWord;
+  occupation: WordListWord;
+  measure: WordListWord;
+  object: WordListWord;
+  religious: WordListWord;
+  other: WordListWord;
+};

--- a/src/routes/wordlist/[language]/+page.svelte
+++ b/src/routes/wordlist/[language]/+page.svelte
@@ -50,7 +50,7 @@
 </h2>
 
 <p style="padding-left: 200px; padding-right: 80px;">
-	The following is the wordlist of Aramaic in the Inscriptions of Israel/Palestine. The list
+	The following is the wordlist of {initialCaps(currentLanguage)} in the Inscriptions of Israel/Palestine. The list
 	presents each headword, its part of speech, and the number of times that word appears in the
 	corpus. To see each of the specific morphological forms, click on the brown button next to the
 	headword. You will be presented with a list of word forms, their morphological data, and counts of

--- a/src/routes/wordlist/under_construction/indices/[language]/+page.server.ts
+++ b/src/routes/wordlist/under_construction/indices/[language]/+page.server.ts
@@ -1,0 +1,44 @@
+import { env } from '$env/dynamic/public';
+import { error } from '@sveltejs/kit';
+
+const AVAILABLE_LANGUAGES = ['latin', 'greek', 'hebrew', 'aramaic'];
+
+/*export async function load({ params }) {
+    const subpageMap = {
+        latin: 'latin',
+        greek: 'greek',
+        aramaic: 'aramaic',
+        hebrew: 'hebrew',
+    };
+    const selectedLang = subpageMap[params.lang];
+    // I'm getting a 500 internal error instead of a 404, not sure why yet
+    if (!selectedLang) {
+        return {
+            status: 404,
+            error: new Error('language error'),
+        };
+    }
+    const response = await fetch(`${env.PUBLIC_API_URL}/wordlist/names/${selectedLang}`);
+    const wordlist = await response.json();
+
+    return { words: wordlist };
+}*/
+
+export async function load({ params }) {
+	const language = params.language.toLowerCase();
+
+	if (!AVAILABLE_LANGUAGES.includes(language)) {
+		throw error(
+			404,
+			`Language ${language} is not supported. Please try one of the supported languages: ${AVAILABLE_LANGUAGES.join(
+				', '
+			)}`
+		);
+	}
+
+	
+	const response = await fetch(`${env.PUBLIC_API_URL}/wordlist/indices/${language}`);
+	const wordlist = await response.json();
+
+	return { AVAILABLE_LANGUAGES, language, indices: wordlist };
+}

--- a/src/routes/wordlist/under_construction/indices/[language]/+page.svelte
+++ b/src/routes/wordlist/under_construction/indices/[language]/+page.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+	import WordListRow from '$lib/components/IndexRow.svelte';
+	import NameRow from '$lib/components/NameRow.svelte';
+	import WordListFilters from '$lib/components/NameFilters.svelte';
+
+	export let data;
+
+	$: languages = data.AVAILABLE_LANGUAGES;
+	$: language = data.language;
+	$: indices = data.indices;
+
+    let keys = [];
+    let count = 0;
+    $: if (indices) {
+        keys = Object.keys(indices);
+    };
+
+    import { onMount } from 'svelte';
+
+    onMount(() => {
+	    var acc = document.getElementsByClassName("accordion");
+        var i;
+
+        for (i = 0; i < acc.length; i++) {
+          acc[i].addEventListener("click", function() {
+            this.classList.toggle("active");
+            var panel = this.nextElementSibling;
+            if (panel.style.display === "block") {
+              panel.style.display = "none";
+            } else {
+              panel.style.display = "block";
+            }
+          });
+        }
+    });
+
+	function initialCaps(s: string) {
+		return `${s[0].toUpperCase()}${s.slice(1)}`;
+	}
+	
+	function headings(s: string) {
+		switch (s) {
+			case 'title':
+				return 'Titles';
+			case 'military':
+				return 'Military Terms';
+			case 'ethnicon':
+				return 'Ethnicons';
+			case 'relationship':
+				return 'Relationship Terms';
+			case 'location':
+				return 'Locations';
+			case 'date':
+				return 'Date Terms';
+			case 'occupation':
+				return 'Occupations';
+			case 'measure':
+				return 'Measures';
+			case 'object':
+				return 'Objects';
+			case 'religious':
+				return 'Religious Terms';
+			case 'other':
+				return 'Other Terms';
+			default:
+				return s;
+		}
+	};
+	
+	function getUniqueTypes(key) {
+		const indexTypes = new Set();
+		indices[key].lemmas.forEach((word) => {
+			const indexType = word.type;
+			if (typeof indexType !== 'undefined') {
+			    const types = indexType.split(',').map(type => type.trim());
+			    types.forEach(type => indexTypes.add(type));
+			}
+		});
+		return Array.from(indexTypes).sort();
+	};
+	
+		function lexicon(s: string) {
+		switch (s) {
+			case 'aramaic':
+				return 'Comprehensive Aramaic Lexicon';
+			case 'greek':
+				return 'Perseus Greek dictionary';
+			case 'hebrew':
+				return 'Morfix Hebrew dictionary';
+			case 'latin':
+				return 'Perseus Latin dictionary';
+			default:
+				return s;
+		}
+	};
+	
+</script>
+
+<!--WordListFilters {words} /-->
+
+<div style="padding-left: 80px; padding-right: 80px; padding-bottom: 80px">
+<p id="lang-select">
+	<span class="italic">Select language:</span>
+	{#each languages as l}
+		<a href="/wordlist/under_construction/indices/{l}" class="px-1" class:font-bold={l === language}
+			>{initialCaps(l)}</a
+		>
+	{/each}
+</p>
+<h2
+	class="font-semibold leading-6 prose prose-h2 prose-stone prose-2xl"
+	style="padding-top: 20px; padding-bottom: 20px"
+>
+	Assorted Indices in {initialCaps(language)}
+</h2>
+
+<p>
+	UNDER CONSTRUCTION
+	<br /><br />
+{#if language != 'aramaic'}
+	The following are a set of word indices for {initialCaps(language)} across various different categories in the Inscriptions of Israel/Palestine. Each index header includes a count of how many unique word lemmas are contained in that index. Click on a header to expand the index and view the contents.
+	<br/><br/>
+	Each index
+	presents each headword, its part of speech, and the number of times that word appears in the
+	corpus. To see each of the specific morphological forms, click on the brown button next to the
+	headword. You will be presented with a list of word forms, their morphological data, and counts of
+	their appearances in the IIP corpus. This display will also show keyword-in-context views,
+	presenting the contexts in which these words appear.
+	<br /><br />
+	Each word in the different indices provides links to the {lexicon(language)}, indicated with the dictionary icon
+	(<img class="sample-icons" alt="dictionary icon" src="/img/dictionary.png" />). 
+{:else}
+    The general indices for Aramaic are not yet available.
+{/if}
+    <br/><br/>
+	For the index of Personal Names in {initialCaps(language)}, <a href="/wordlist/under_construction/names/{language}" style="color: grey">click here</a>. For the general {initialCaps(language)} wordlist, <a href="/wordlist/{language}" style="color: grey">click here</a>.
+	<br/><br/>
+</p>
+
+{#each keys as key}
+    {#if indices[key].lemmas.length > 0}
+        <button class="accordion"><span class="font-semibold leading-6 prose prose-h2 prose-stone prose-xl">Index of {headings(key)}</span>
+        ({indices[key].lemmas.length} term{#if indices[key].lemmas.length > 1}s{/if})</button>
+        <div class="panel">
+            <p style="padding-left: 20px;">
+                <span class="font-bold">Categories:</span>
+                <br/>
+            	{#each getUniqueTypes(key) as t}
+	                <button style="background-color: #e3e0d8; padding: 5px; border-radius: 13px; border: 5px solid white;"> {t} </button>
+	            {/each}
+	        </p>
+            <!--p>
+	            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus mollis lorem ligula, id volutpat
+	            tortor condimentum id. Ut bibendum tincidunt neque. Proin eu augue ut urna viverra fringilla. Praesent
+	            bibendum finibus elementum. Suspendisse augue sapien, eleifend ut est et, ultricies dignissim nisi.
+	            Sed bibendum luctus ligula, quis tempor elit eleifend eget. Cras sed pretium nisi. Donec imperdiet
+	            enim in vestibulum dictum. Vivamus ultrices euismod urna a convallis. Maecenas fringilla tortor non
+	            tempus ultrices.<br /><br />
+            </p-->
+
+            <div class="container text-left">
+	            <table id="latin-pos-table" class="table-auto" width="100%">
+		            {#each indices[key].lemmas as word, index}
+			            <WordListRow {word} treeData="" id={(index + 1).toString()} language={language} wordType="true" />
+		            {/each}
+	            </table>
+            </div>
+        </div>
+    {/if}
+{/each}
+
+</div>

--- a/src/routes/wordlist/under_construction/names/[language]/+page.svelte
+++ b/src/routes/wordlist/under_construction/names/[language]/+page.svelte
@@ -12,7 +12,22 @@
 
 	function initialCaps(s: string) {
 		return `${s[0].toUpperCase()}${s.slice(1)}`;
-	}
+	};
+	
+	function lexicon(s: string) {
+		switch (s) {
+			case 'aramaic':
+				return 'Comprehensive Aramaic Lexicon';
+			case 'greek':
+				return 'Perseus Greek dictionary';
+			case 'hebrew':
+				return 'Morfix Hebrew dictionary';
+			case 'latin':
+				return 'Perseus Latin dictionary';
+			default:
+				return s;
+		}
+	};
 </script>
 
 <WordListFilters {words} />
@@ -35,12 +50,23 @@
 <p style="padding-left: 200px; padding-right: 80px;">
 	UNDER CONSTRUCTION
 	<br /><br />
-	Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus mollis lorem ligula, id volutpat
-	tortor condimentum id. Ut bibendum tincidunt neque. Proin eu augue ut urna viverra fringilla. Praesent
-	bibendum finibus elementum. Suspendisse augue sapien, eleifend ut est et, ultricies dignissim nisi.
-	Sed bibendum luctus ligula, quis tempor elit eleifend eget. Cras sed pretium nisi. Donec imperdiet
-	enim in vestibulum dictum. Vivamus ultrices euismod urna a convallis. Maecenas fringilla tortor non
-	tempus ultrices.<br /><br />
+	{#if language != 'aramaic'}
+	The following is list of personal names in {initialCaps(language)} in the Inscriptions of Israel/Palestine. 
+	The list presents each headword for the name, the number of times that name appears in the corpus, the
+	gender of the name, and whether the name has been categorized as a Christian one, a Jewish one, or other.
+	{:else}
+	The following is list of personal names in {initialCaps(language)} in the Inscriptions of Israel/Palestine. 
+	The list presents each headword for the name and the number of times that name appears in the corpus. 
+	<span style="text-decoration: underline;">Data for the gender of the name and the categorization for the name is not yet available for Aramaic.</span>
+	{/if}
+	<br/><br/>
+	To see each of the specific morphological forms, click on the brown button next to the
+	headword. You will be presented with a list of forms, their morphological data, and counts of
+	their appearances in the IIP corpus. This display will also show keyword-in-context views,
+	presenting the contexts in which these names appear.
+	<br/><br/>
+	For the other indices for {initialCaps(language)}, <a href="/wordlist/under_construction/indices/{language}" style="color: grey">click here</a>. For the general {initialCaps(language)} wordlist, <a href="/wordlist/{language}" style="color: grey">click here</a>.
+	<br /><br />
 </p>
 
 <div class="container text-left" style="padding-left: 200px;">

--- a/static/vendor/wordlist.css
+++ b/static/vendor/wordlist.css
@@ -85,4 +85,24 @@ a > b {
 	color: #00455D;
 }
 
+.accordion {
+  background-color: #e3e0d8;
+  padding: 20px;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  transition: 0.4s;
+  border-bottom: 1px solid black;
+}
+
+.active, .accordion:hover {
+  background-color: #c0beb7; 
+}
+
+.panel {
+  display: none;
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+
 


### PR DESCRIPTION
Thanks for the updates to handle the different wordlist languages more cleanly! I noticed that the language switch wasn't handled in just one spot in the intro, so I'm inserting a quick fix for that.